### PR TITLE
Update for inbox and handling network-error

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,107 +2,153 @@ import 'package:flutter/material.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
-import 'dart:convert';
-import 'dart:io';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_messaging/firebase_messaging.dart';
+import 'package:connectivity_plus/connectivity_plus.dart';
+import 'dart:convert'; // jsonを使用するため
+import 'package:flutter/foundation.dart'; // kIsWebを使用
+
 import './page.dart' as page;
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
-  await dotenv.load(fileName: '.env');
-  await Supabase.initialize(
-    url: dotenv.get('SUPABASE_URL'),
-    anonKey: dotenv.get('SUPABASE_KEY'),
-  );
-
-  await Firebase.initializeApp();
-
-  final messagingInstance = FirebaseMessaging.instance;
-  messagingInstance.requestPermission();
-
-  final fcmToken = await messagingInstance.getToken();
-  debugPrint('FCM TOKEN: $fcmToken');
-
-  final fcmtopic = await messagingInstance.subscribeToTopic('allUsers');
-
-  final flutterLocalNotificationsPlugin = FlutterLocalNotificationsPlugin();
-  if (Platform.isAndroid) {
-    final androidImplementation =
-    flutterLocalNotificationsPlugin.resolvePlatformSpecificImplementation<
-        AndroidFlutterLocalNotificationsPlugin>();
-    await androidImplementation?.createNotificationChannel(
-      const AndroidNotificationChannel(
-        'default_notification_channel',
-        'プッシュ通知のチャンネル名',
-        importance: Importance.max,
-      ),
-    );
-    await androidImplementation?.requestNotificationsPermission();
-  }
-
-  // 通知設定の初期化を行う
-  _initNotification();
-
-  // アプリ停止時に通知をタップした場合はgetInitialMessageでメッセージデータを取得できる
-  final message = await FirebaseMessaging.instance.getInitialMessage();
-  // 取得したmessageを利用した処理などを記載する
 
   runApp(const MaterialApp(
-          title: 'LatinOne',
-          home: page.Page(title: 'LatinOne'),
-      ));
+    title: 'LatinOne',
+    home: ConnectionChecker(),
+  ));
 }
 
-Future<void> _initNotification() async {
-  final flutterLocalNotificationsPlugin = FlutterLocalNotificationsPlugin();
+class ConnectionChecker extends StatefulWidget {
+  const ConnectionChecker({Key? key}) : super(key: key);
 
-  FirebaseMessaging.onMessageOpenedApp.listen((RemoteMessage message) {
-    // バックグラウンド起動中に通知をタップした場合の処理
-  });
+  @override
+  _ConnectionCheckerState createState() => _ConnectionCheckerState();
+}
 
-  FirebaseMessaging.onMessage.listen((RemoteMessage message) async {
-    final notification = message.notification;
-    debugPrint('Message: $notification');
-    final android = message.notification?.android;
+class _ConnectionCheckerState extends State<ConnectionChecker> {
+  bool _isDialogShowing = false;
 
-    // フォアグラウンド起動中に通知が来た場合の処理
+  @override
+  void initState() {
+    super.initState();
+    _checkConnectivity();
+  }
 
-    // フォアグラウンド起動中に通知が来た場合、
-    // Androidは通知が表示されないため、ローカル通知として表示する
-    // https://firebase.flutter.dev/docs/messaging/notifications#application-in-foreground
-    if (Platform.isAndroid) {
-      // プッシュ通知をローカルから表示する
-      await FlutterLocalNotificationsPlugin().show(
-        0,
-        notification!.title,
-        notification.body,
-        NotificationDetails(
-          android: AndroidNotificationDetails(
-            'default_notification_channel',
-            'プッシュ通知のチャンネル名',
-            importance: Importance.max, // 通知の重要度の設定
-            icon: android?.smallIcon,
-          ),
+  Future<void> _checkConnectivity() async {
+    final connectivityResult = await Connectivity().checkConnectivity();
+    if (connectivityResult == ConnectivityResult.none) {
+      _showNoConnectionDialog();
+    } else {
+      await _initializeApp();
+    }
+  }
+
+  Future<void> _initializeApp() async {
+    await dotenv.load(fileName: '.env');
+    await Supabase.initialize(
+      url: dotenv.maybeGet('SUPABASE_URL') ?? 'default_url',
+      anonKey: dotenv.maybeGet('SUPABASE_KEY') ?? 'default_key',
+    );
+
+    try {
+      await Firebase.initializeApp();
+    } catch (e) {
+      debugPrint('Firebase initialization failed: $e');
+    }
+
+    final messagingInstance = FirebaseMessaging.instance;
+    messagingInstance.requestPermission();
+
+    try {
+      final fcmToken = await messagingInstance.getToken();
+      debugPrint('FCM TOKEN: $fcmToken');
+      await messagingInstance.subscribeToTopic('allUsers');
+    } catch (e) {
+      debugPrint('Failed to get FCM token or subscribe to topic: $e');
+    }
+
+    final flutterLocalNotificationsPlugin = FlutterLocalNotificationsPlugin();
+    if (!kIsWeb) {
+      final androidImplementation = flutterLocalNotificationsPlugin
+          .resolvePlatformSpecificImplementation<
+              AndroidFlutterLocalNotificationsPlugin>();
+      await androidImplementation?.createNotificationChannel(
+        const AndroidNotificationChannel(
+          'default_notification_channel',
+          'プッシュ通知のチャンネル名',
+          importance: Importance.max,
         ),
-        payload: json.encode(message.data),
       );
     }
-  });
 
-  // ローカルから表示したプッシュ通知をタップした場合の処理を設定
-  flutterLocalNotificationsPlugin.initialize(
-    const InitializationSettings(
-      android: AndroidInitializationSettings(
-          '@mipmap/ic_launcher'), //通知アイコンの設定は適宜行ってください
-      iOS: DarwinInitializationSettings(),
-    ),
-    onDidReceiveNotificationResponse: (details) {
-      if (details.payload != null) {
-        final payloadMap =
-        json.decode(details.payload!) as Map<String, dynamic>;
-        debugPrint(payloadMap.toString());
+    _initNotification();
+  }
+
+  Future<void> _initNotification() async {
+    final flutterLocalNotificationsPlugin = FlutterLocalNotificationsPlugin();
+
+    FirebaseMessaging.onMessage.listen((RemoteMessage message) async {
+      final notification = message.notification;
+      if (!kIsWeb && notification != null) {
+        await flutterLocalNotificationsPlugin.show(
+          0,
+          notification.title,
+          notification.body,
+          NotificationDetails(
+            android: AndroidNotificationDetails(
+              'default_notification_channel',
+              'プッシュ通知のチャンネル名',
+              importance: Importance.max,
+              icon: notification.android?.smallIcon,
+            ),
+          ),
+          payload: json.encode(message.data),
+        );
       }
-    },
-  );
+    });
+
+    flutterLocalNotificationsPlugin.initialize(
+      const InitializationSettings(
+        android: AndroidInitializationSettings('@mipmap/ic_launcher'),
+        iOS: DarwinInitializationSettings(),
+      ),
+      onDidReceiveNotificationResponse: (details) {
+        if (details.payload != null) {
+          final payloadMap =
+              json.decode(details.payload!) as Map<String, dynamic>;
+          debugPrint(payloadMap.toString());
+        }
+      },
+    );
+  }
+
+  void _showNoConnectionDialog() {
+    if (_isDialogShowing) return; // ダイアログが既に表示されている場合は表示しない
+
+    _isDialogShowing = true;
+    showDialog(
+      context: context,
+      builder: (BuildContext context) {
+        return AlertDialog(
+          title: const Text('ネットワーク接続なし'),
+          content: const Text('インターネットに接続されていません。接続を確認してください。'),
+          actions: [
+            TextButton(
+              onPressed: () {
+                Navigator.of(context).pop();
+                _isDialogShowing = false;
+              },
+              child: const Text('OK'),
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return page.Page(title: 'LatinOne');
+  }
 }

--- a/lib/page.dart
+++ b/lib/page.dart
@@ -2,11 +2,13 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:connectivity_plus/connectivity_plus.dart';
+import 'package:firebase_messaging/firebase_messaging.dart';
 
 import './screen/home.dart';
 import './screen/order.dart';
 import './screen/shops.dart';
 import './screen/inbox.dart';
+import './screen/product.dart';
 import './style.dart';
 
 class Page extends StatefulWidget {
@@ -19,16 +21,15 @@ class Page extends StatefulWidget {
 
 class Pages extends State<Page> {
   int _selectedIndex = 0;
-  final _pageWidgets = [
-    const HomePage(),
-    const ShopsPage(),
-    const OrderPage(),
-  ];
+  final List<Map<String, String>> _notifications = [];
+  final _pageWidgets = <Widget>[];
 
   late Connectivity _connectivity;
-  late StreamSubscription<ConnectivityResult> _connectivitySubscription;
+  StreamSubscription<List<ConnectivityResult>>? _connectivitySubscription;
+  StreamSubscription<RemoteMessage>? _messageSubscription;
   Timer? _timer;
   bool _isConnected = true;
+  bool _isDialogShowing = false;
 
   @override
   void initState() {
@@ -36,34 +37,57 @@ class Pages extends State<Page> {
     _connectivity = Connectivity();
     _startConnectivityMonitoring();
     _startPeriodicCheck();
+
+    _initializeFirebaseMessaging();
+
+    _pageWidgets.addAll([
+      const HomePage(),
+      const ShopsPage(),
+      const OrderPage(),
+    ]);
+  }
+
+  void _initializeFirebaseMessaging() {
+    // FirebaseMessagingリスナーの登録
+    _messageSubscription = FirebaseMessaging.onMessage.listen((RemoteMessage message) {
+      if (message.notification != null) {
+        setState(() {
+          _notifications.add({
+            'title': message.notification!.title ?? 'No Title',
+            'body': message.notification!.body ?? 'No Body',
+          });
+        });
+      }
+    });
   }
 
   void _startConnectivityMonitoring() {
-    _connectivitySubscription = _connectivity.onConnectivityChanged.listen((ConnectivityResult result) {
+    _connectivitySubscription = _connectivity.onConnectivityChanged.listen((List<ConnectivityResult> results) {
       setState(() {
-        _isConnected = result != ConnectivityResult.none;
+        _isConnected = results.any((result) => result != ConnectivityResult.none);
       });
 
-      if (!_isConnected) {
+      if (!_isConnected && !_isDialogShowing) {
         _showNoConnectionDialog();
       }
     });
   }
 
   void _startPeriodicCheck() {
-    _timer = Timer.periodic(Duration(seconds: 10), (Timer t) async {
+    _timer = Timer.periodic(const Duration(seconds: 5), (Timer t) async {
       var result = await _connectivity.checkConnectivity();
       setState(() {
         _isConnected = result != ConnectivityResult.none;
       });
 
-      if (!_isConnected) {
+      if (!_isConnected && !_isDialogShowing) {
         _showNoConnectionDialog();
       }
     });
   }
 
   void _showNoConnectionDialog() {
+    _isDialogShowing = true;
     showDialog(
       context: context,
       builder: (BuildContext context) {
@@ -74,6 +98,7 @@ class Pages extends State<Page> {
             TextButton(
               onPressed: () {
                 Navigator.of(context).pop();
+                _isDialogShowing = false;
               },
               child: const Text('OK'),
             ),
@@ -85,7 +110,8 @@ class Pages extends State<Page> {
 
   @override
   void dispose() {
-    _connectivitySubscription.cancel();
+    _connectivitySubscription?.cancel();
+    _messageSubscription?.cancel(); // FirebaseMessagingリスナーの解除
     _timer?.cancel();
     super.dispose();
   }
@@ -110,32 +136,40 @@ class Pages extends State<Page> {
   Widget build(BuildContext context) {
     return MaterialApp(
       title: 'Standard AppBar',
-      home: PopScope(
-        canPop: false,
-        onPopInvoked: (popDisposition) {
+      home: WillPopScope(
+        onWillPop: () async {
           _handlePopInvoked();
+          return false;
         },
         child: Scaffold(
           appBar: AppBar(
             centerTitle: true,
             title: const Text('LatinOne', style: Default_title_Style),
             backgroundColor: Colors.brown,
-            leading: InkWell(
-              onTap: () {
-                Navigator.push(context,
-                    MaterialPageRoute(builder: (context) => const InboxPage()));
-              },
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.center,
-                children: [
-                  Image.asset(
-                    'assets/images/inbox_icon.png',
-                    fit: BoxFit.contain,
-                    height: 50,
-                  ),
-                ],
+            leading: IconButton(
+          icon: const Icon(Icons.inbox),
+          onPressed: () async {
+            final result = await Navigator.push(
+              context,
+              MaterialPageRoute(
+                builder: (context) => InboxPage(notifications: _notifications),
               ),
-            ),
+            );
+
+            if (result == 'shops') {
+              setState(() {
+                _selectedIndex = 1;
+              });
+            } else if (result == 'products') {
+              Navigator.push(
+                          context,
+                          MaterialPageRoute(
+                            builder: (context) => const ProductPage(isFromHomePage: true),
+                          ),
+                        );
+            }
+          },
+        ),
           ),
           body: IndexedStack(
             index: _selectedIndex,

--- a/lib/screen/inbox.dart
+++ b/lib/screen/inbox.dart
@@ -1,24 +1,68 @@
 import 'package:flutter/material.dart';
 
-class InboxPage extends StatelessWidget {
-  const InboxPage({super.key});
+class InboxPage extends StatefulWidget {
+  final List<Map<String, dynamic>> notifications;
+
+  const InboxPage({super.key, required this.notifications});
+
+  @override
+  _InboxPageState createState() => _InboxPageState();
+}
+
+class _InboxPageState extends State<InboxPage> {
+  @override
+  void initState() {
+    super.initState();
+    print('通知リスト: ${widget.notifications}');
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
         title: const Text('Inbox'),
       ),
-      body: Container(
-        padding: const EdgeInsets.all(32.0),
-        child: const Center(
-          child: Column(
-            mainAxisAlignment: MainAxisAlignment.center,
-            children: <Widget>[
-              Text('To be continued...'),
-            ],
-          ),
-        ),
-      ),
+      body: widget.notifications.isEmpty
+          ? const Center(
+              child: Text('通知はありません'),
+            )
+          : ListView.builder(
+              padding: const EdgeInsets.all(16.0),
+              itemCount: widget.notifications.length,
+              itemBuilder: (context, index) {
+                final notification = widget.notifications[index];
+                final title = notification['title'] is String
+                    ? notification['title']
+                    : 'No Title';
+                final body = notification['body'] is String
+                    ? notification['body']
+                    : 'No Body';
+                final isRead = notification['isRead'] ?? false;
+
+                return Card(
+                  child: ListTile(
+                    title: Text(
+                      title,
+                      style: TextStyle(
+                        fontWeight:
+                            isRead ? FontWeight.normal : FontWeight.bold,
+                      ),
+                    ),
+                    subtitle: Text(body),
+                    trailing: isRead
+                        ? const Icon(Icons.check, color: Colors.green)
+                        : null,
+                    onTap: () {
+                      if (title.contains('店舗')) {
+                        Navigator.pop(context, 'shops');
+                      } else if (title.contains('商品')) {
+                        Navigator.pop(context, 'products');
+                      }
+                    },
+                  ),
+                );
+              },
+            ),
     );
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -28,7 +28,7 @@ environment:
 # the latest version available on pub.dev. To see which dependencies have newer
 # versions available, run `flutter pub outdated`.
 dependencies:
-  email_validator: '^2.1.17'
+  email_validator: ^3.0.0
   flutter:
     sdk: flutter
 
@@ -43,11 +43,13 @@ dependencies:
   flutter_dotenv: ^5.1.0
   supabase_flutter: ^2.6.0
   shared_preferences: ^2.0.9
-  connectivity_plus: ^3.0.3
-  flutter_local_notifications: ^17.2.3
+  connectivity_plus: ^6.1.0
+  flutter_local_notifications: ^18.0.1
   firebase_core: ^3.4.0
   firebase_messaging: ^15.1.0
+  firebase_analytics: ^11.3.0
 
+  http: any
 dev_dependencies:
   flutter_test:
     sdk: flutter
@@ -57,7 +59,7 @@ dev_dependencies:
   # activated in the `analysis_options.yaml` file located at the root of your
   # package. See that file for information about deactivating specific lint
   # rules and activating additional ones.
-  flutter_lints: ^3.0.0
+  flutter_lints: ^4.0.0
 
 # For information on the generic Dart part of this file, see the
 # following page: https://dart.dev/tools/pub/pubspec


### PR DESCRIPTION
## 概要
1. network error に関するハンドリングを修正
2. inbox 通知の実装
## 内容
1. page.dartでのエラーハンドリングに加えてmain.dartにおける起動時の処理にエラーハンドリングを追加
2. 通知内容をinboxに通知するように変更
　2.1 shopsに関する通知をクリックするとshopsページへ
   2.2 productsに関する通知をクリックするとmenuページへ