### PR TITLE
Update inbox

### DIFF
--- a/lib/screen/inbox.dart
+++ b/lib/screen/inbox.dart
@@ -1,19 +1,58 @@
 import 'package:flutter/material.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
 
 class InboxPage extends StatefulWidget {
   final List<Map<String, dynamic>> notifications;
+  final String deviceToken;
+  final String initialTab;
 
-  const InboxPage({super.key, required this.notifications});
+  const InboxPage({
+    super.key,
+    required this.notifications,
+    required this.deviceToken,
+    this.initialTab = 'news',
+  });
 
   @override
   _InboxPageState createState() => _InboxPageState();
 }
 
-class _InboxPageState extends State<InboxPage> {
+class _InboxPageState extends State<InboxPage> with SingleTickerProviderStateMixin {
+  late TabController _tabController;
+  List<Map<String, dynamic>> news = [];
+  List<Map<String, dynamic>> messages = [];
+  final supabase = Supabase.instance.client;
+
+  Future<void> fetchMenu() async {
+    try {
+      final response = await supabase.from('inboxs').select();
+      setState(() {
+        news = response.cast<Map<String, dynamic>>().reversed.take(10).toList();
+      });
+        } catch (e) {
+      debugPrint('Error fetching menu: $e');
+    }
+  }
+
   @override
   void initState() {
     super.initState();
-    print('通知リスト: ${widget.notifications}');
+
+    // 初期タブを設定
+    _tabController = TabController(
+      length: 2,
+      vsync: this,
+      initialIndex: widget.initialTab == 'message' ? 1 : 0,
+    );
+
+    messages = widget.notifications;
+    fetchMenu();
+  }
+
+  @override
+  void dispose() {
+    _tabController.dispose();
+    super.dispose();
   }
 
   @override
@@ -21,48 +60,83 @@ class _InboxPageState extends State<InboxPage> {
     return Scaffold(
       appBar: AppBar(
         title: const Text('Inbox'),
+        bottom: TabBar(
+          controller: _tabController,
+          tabs: const [
+            Tab(text: 'News'),
+            Tab(text: 'Message'),
+          ],
+        ),
       ),
-      body: widget.notifications.isEmpty
-          ? const Center(
-              child: Text('通知はありません'),
-            )
-          : ListView.builder(
-              padding: const EdgeInsets.all(16.0),
-              itemCount: widget.notifications.length,
-              itemBuilder: (context, index) {
-                final notification = widget.notifications[index];
-                final title = notification['title'] is String
-                    ? notification['title']
-                    : 'No Title';
-                final body = notification['body'] is String
-                    ? notification['body']
-                    : 'No Body';
-                final isRead = notification['isRead'] ?? false;
+      body: TabBarView(
+        controller: _tabController,
+        children: [
+          // News Tab
+          news.isEmpty
+              ? const Center(
+            child: Text('Newsはまだありません'),
+          )
+              : ListView.builder(
+            padding: const EdgeInsets.all(16.0),
+            itemCount: news.length,
+            itemBuilder: (context, index) {
+              final item = news[index];
+              final title = item['title'] ?? 'No Title';
+              final description = item['description'] ?? 'No Description';
 
-                return Card(
-                  child: ListTile(
-                    title: Text(
-                      title,
-                      style: TextStyle(
-                        fontWeight:
-                            isRead ? FontWeight.normal : FontWeight.bold,
-                      ),
+              return Card(
+                child: ListTile(
+                  title: Text(title),
+                  subtitle: Text(description),
+                  onTap: () {
+                    if (title.contains('店舗')) {
+                      Navigator.pop(context, 'shops');
+                    } else if (title.contains('商品')) {
+                      Navigator.pop(context, 'products');
+                    }
+                  },
+                ),
+              );
+            },
+          ),
+          // Message Tab
+          messages.isEmpty
+              ? const Center(
+            child: Text('通知はありません'),
+          )
+              : ListView.builder(
+            padding: const EdgeInsets.all(16.0),
+            itemCount: messages.length,
+            itemBuilder: (context, index) {
+              final notification = messages[index];
+              final title = notification['title'] is String
+                  ? notification['title']
+                  : 'No Title';
+              final body = notification['body'] is String
+                  ? notification['body']
+                  : 'No Body';
+              final isRead = notification['isRead'] ?? false;
+
+              return Card(
+                child: ListTile(
+                  title: Text(
+                    title,
+                    style: TextStyle(
+                      fontWeight: isRead
+                          ? FontWeight.normal
+                          : FontWeight.bold,
                     ),
-                    subtitle: Text(body),
-                    trailing: isRead
-                        ? const Icon(Icons.check, color: Colors.green)
-                        : null,
-                    onTap: () {
-                      if (title.contains('店舗')) {
-                        Navigator.pop(context, 'shops');
-                      } else if (title.contains('商品')) {
-                        Navigator.pop(context, 'products');
-                      }
-                    },
                   ),
-                );
-              },
-            ),
+                  subtitle: Text(body),
+                  trailing: isRead
+                      ? const Icon(Icons.check, color: Colors.green)
+                      : null,
+                ),
+              );
+            },
+          ),
+        ],
+      ),
     );
   }
 }


### PR DESCRIPTION
# 概要
1. inbox ページ内に
個人宛: 履歴を残して見にいく
全体宛: supabase inbox テーブルを見に行く
の2つを切り替えできる仕組みを作って

2. push 通知をクリックすると Inbox ページに遷移
個人宛: inbox の個人宛に遷移
全体宛: inbox の全体宛に遷移