### PR TITLE
Update main for pushing and inbox

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,220 +2,127 @@ import 'package:flutter/material.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
+import 'dart:convert';
+import 'dart:io';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_messaging/firebase_messaging.dart';
-import 'package:connectivity_plus/connectivity_plus.dart';
-import 'package:shared_preferences/shared_preferences.dart'; // 追加
-import 'dart:convert'; // jsonを使用するため
-import 'package:flutter/foundation.dart'; // kIsWebを使用
-
 import './page.dart' as page;
+import 'package:shared_preferences/shared_preferences.dart';
+
+final GlobalKey<NavigatorState> navigatorKey = GlobalKey<NavigatorState>();
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
+  await dotenv.load(fileName: '.env');
+  await Supabase.initialize(
+    url: dotenv.get('SUPABASE_URL'),
+    anonKey: dotenv.get('SUPABASE_KEY'),
+  );
+  await Firebase.initializeApp();
+  final String? fcmToken = await FirebaseMessaging.instance.getToken();
 
-  runApp(const MaterialApp(
+  _initNotification(fcmToken);
+  final message = await FirebaseMessaging.instance.getInitialMessage();
+  if (message != null) {
+    _handleInitialMessage(message, fcmToken);
+  }
+
+  runApp(MaterialApp(
     title: 'LatinOne',
-    home: ConnectionChecker(),
+    navigatorKey: navigatorKey,
+    home: page.Page(title: 'LatinOne', fcmToken: fcmToken ?? ''),
   ));
 }
 
-class ConnectionChecker extends StatefulWidget {
-  const ConnectionChecker({super.key});
-
-  @override
-  _ConnectionCheckerState createState() => _ConnectionCheckerState();
-}
-
-class _ConnectionCheckerState extends State<ConnectionChecker> {
-  bool _isDialogShowing = false;
-  String? _myFcmToken; // 自分の FCM トークンを保持する変数
-
-  @override
-  void initState() {
-    super.initState();
-    _checkConnectivity();
-  }
-
-  Future<void> _checkConnectivity() async {
-    final connectivityResult = await Connectivity().checkConnectivity();
-    if (connectivityResult == ConnectivityResult.none) {
-      _showNoConnectionDialog();
-    } else {
-      await _initializeApp();
-    }
-  }
-
-  Future<void> _initializeApp() async {
-    await dotenv.load(fileName: '.env');
-    await Supabase.initialize(
-      url: dotenv.maybeGet('SUPABASE_URL') ?? 'default_url',
-      anonKey: dotenv.maybeGet('SUPABASE_KEY') ?? 'default_key',
-    );
-
-    try {
-      await Firebase.initializeApp();
-    } catch (e) {
-      debugPrint('Firebase initialization failed: $e');
-    }
-
-    final messagingInstance = FirebaseMessaging.instance;
-    messagingInstance.requestPermission();
-
-    try {
-      _myFcmToken = await messagingInstance.getToken(); // 自分のトークンを取得
-      debugPrint('FCM TOKEN: $_myFcmToken');
-      await messagingInstance.subscribeToTopic('allUsers');
-    } catch (e) {
-      debugPrint('Failed to get FCM token or subscribe to topic: $e');
-      _myFcmToken = ''; // エラー時は空文字列
-    }
-
-    final flutterLocalNotificationsPlugin = FlutterLocalNotificationsPlugin();
-    if (!kIsWeb) {
-      final androidImplementation = flutterLocalNotificationsPlugin
-          .resolvePlatformSpecificImplementation<
-          AndroidFlutterLocalNotificationsPlugin>();
-      await androidImplementation?.createNotificationChannel(
-        const AndroidNotificationChannel(
-          'default_notification_channel',
-          'プッシュ通知のチャンネル名',
-          importance: Importance.max,
-        ),
-      );
-    }
-
-    _initNotification();
-
-    Navigator.pushReplacement(
-      context,
+void _handleInitialMessage(RemoteMessage message, String? fcmToken) {
+  final data = message.data;
+  if (data['type'] == 'news') {
+    navigatorKey.currentState?.push(
       MaterialPageRoute(
-        builder: (context) => page.Page(
-          title: 'LatinOne',
-          fcmToken: _myFcmToken ?? '', // fcmToken が null の場合は空文字を渡す
-        ),
+        builder: (context) => page.Page(title: 'News Page', fcmToken: fcmToken ?? ''),
+      ),
+    );
+  } else {
+    navigatorKey.currentState?.push(
+      MaterialPageRoute(
+        builder: (context) => page.Page(title: 'Message Page', fcmToken: fcmToken ?? ''),
       ),
     );
   }
+}
 
-  Future<void> _initNotification() async {
-    final flutterLocalNotificationsPlugin = FlutterLocalNotificationsPlugin();
+Future<void> _initNotification(String? fcmToken) async {
+  final flutterLocalNotificationsPlugin = FlutterLocalNotificationsPlugin();
 
-    FirebaseMessaging.onMessage.listen((RemoteMessage message) async {
-      final notification = message.notification;
+  FirebaseMessaging.onMessageOpenedApp.listen((RemoteMessage message) {
+    _handleInitialMessage(message, fcmToken);
+  });
 
-      // 自分のトークン宛かどうかを確認
-      if (message.data['to'] == _myFcmToken) {
-        if (!kIsWeb && notification != null) {
-          // 通知データをローカルに保存
-          await _saveNotificationLocally({
-            'title': notification.title,
-            'body': notification.body,
-            'data': message.data,
-          });
+  FirebaseMessaging.onMessage.listen((RemoteMessage message) async {
+    final notification = message.notification;
+    final data = message.data;
 
-          // 通知を表示
-          await flutterLocalNotificationsPlugin.show(
-            0,
-            notification.title,
-            notification.body,
-            NotificationDetails(
-              android: AndroidNotificationDetails(
-                'default_notification_channel',
-                'プッシュ通知のチャンネル名',
-                importance: Importance.max,
-                icon: notification.android?.smallIcon,
-              ),
+    if (Platform.isAndroid && notification != null) {
+      await flutterLocalNotificationsPlugin.show(
+        0,
+        notification.title,
+        notification.body,
+        const NotificationDetails(
+          android: AndroidNotificationDetails(
+            'default_notification_channel',
+            'プッシュ通知のチャンネル名',
+            importance: Importance.max,
+            icon: '@mipmap/ic_launcher',
+          ),
+        ),
+        payload: json.encode(message.data),
+      );
+
+        await _saveNotificationLocally({
+          'title': notification.title,
+          'body': notification.body,
+          'data': data,
+        });
+    }
+  });
+
+  flutterLocalNotificationsPlugin.initialize(
+    const InitializationSettings(
+      android: AndroidInitializationSettings('@mipmap/ic_launcher'),
+      iOS: DarwinInitializationSettings(),
+    ),
+    onDidReceiveNotificationResponse: (details) {
+      if (details.payload != null) {
+        final payloadMap =
+        json.decode(details.payload!) as Map<String, dynamic>;
+        if (payloadMap['type'] == 'news') {
+          navigatorKey.currentState?.push(
+            MaterialPageRoute(
+              builder: (context) =>
+                  page.Page(title: 'News Page', fcmToken: fcmToken ?? ''),
             ),
-            payload: json.encode(message.data),
+          );
+        } else {
+          navigatorKey.currentState?.push(
+            MaterialPageRoute(
+              builder: (context) =>
+                  page.Page(title: 'Message Page', fcmToken: fcmToken ?? ''),
+            ),
           );
         }
       }
-    });
+    },
+  );
+}
 
-    flutterLocalNotificationsPlugin.initialize(
-      const InitializationSettings(
-        android: AndroidInitializationSettings('@mipmap/ic_launcher'),
-        iOS: DarwinInitializationSettings(),
-      ),
-      onDidReceiveNotificationResponse: (details) {
-        if (details.payload != null) {
-          final payloadMap =
-          json.decode(details.payload!) as Map<String, dynamic>;
-
-          // type に基づいて処理を分岐
-          if (payloadMap['to'] == _myFcmToken) {
-            debugPrint('Type: message');
-            Navigator.push(
-              context,
-              MaterialPageRoute(
-                builder: (context) => page.Page(
-                  title: 'LatinOne',
-                  fcmToken: _myFcmToken ?? '',
-                  type: 'message',
-                ),
-              ),
-            );
-          } else {
-            debugPrint('Type: news');
-            Navigator.push(
-              context,
-              MaterialPageRoute(
-                builder: (context) => page.Page(
-                  title: 'LatinOne',
-                  fcmToken: _myFcmToken ?? '',
-                  type: 'news',
-                ),
-              ),
-            );
-          }
-        }
-      },
-    );
-  }
-
-  Future<void> _saveNotificationLocally(
-      Map<String, dynamic> notification) async {
+Future<void> _saveNotificationLocally(Map<String, dynamic> notification) async {
+  if (!notification['title'].contains('情報')) {
     final prefs = await SharedPreferences.getInstance();
     final notifications = prefs.getStringList('notifications') ?? [];
-
-    // 新しい通知を追加
     notifications.add(json.encode(notification));
-
-    // 保存
     await prefs.setStringList('notifications', notifications);
-  }
-
-  void _showNoConnectionDialog() {
-    if (_isDialogShowing) return;
-
-    _isDialogShowing = true;
-    showDialog(
-      context: context,
-      builder: (BuildContext context) {
-        return AlertDialog(
-          title: const Text('ネットワーク接続なし'),
-          content: const Text('インターネットに接続されていません。接続を確認してください。'),
-          actions: [
-            TextButton(
-              onPressed: () {
-                Navigator.of(context).pop();
-                _isDialogShowing = false;
-              },
-              child: const Text('OK'),
-            ),
-          ],
-        );
-      },
-    );
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return const Scaffold(
-      body: Center(
-        child: CircularProgressIndicator(), // ローディング画面
-      ),
-    );
+    debugPrint('通知を保存しました（情報を含む）');
+  } else {
+    debugPrint('通知を保存しませんでした（情報を含まない）');
   }
 }


### PR DESCRIPTION
1. Push通知の復活
　一度，Push 通知が動いていたコミットをもとに修正 (https://github.com/KentaYoshioka/latin_one/commit/7ec2634e378347ba2bdd6e370bb299b1757f26ad)
　networkエラーハンドリングの部分を消去
2. Inbox の Message 画面の改修
　localストレージに保存する部分で更新情報か否か判定する機能の追加
